### PR TITLE
Italics rule for reST is wrong

### DIFF
--- a/Syntaxes/reStructuredText.plist
+++ b/Syntaxes/reStructuredText.plist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>comment</key>
@@ -169,7 +169,7 @@
 					<key>comment</key>
 					<string>emphasis</string>
 					<key>match</key>
-					<string>(\*)\w[^*]\w+(\*)</string>
+					<string>(\*)\w[^*]+\w(\*)</string>
 					<key>name</key>
 					<string>markup.italic.restructuredtext</string>
 				</dict>


### PR DESCRIPTION
The italics rule won't detect things like "_some-text_" as italics; moved the match operator over to fix this.
