### PR TITLE
These are some corrections on the syntax definition. The following example sums it up.

### DIFF
--- a/Syntaxes/reStructuredText.plist
+++ b/Syntaxes/reStructuredText.plist
@@ -622,7 +622,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>^(\.\.)</string>
+					<string>^(\.\.)\s</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -634,7 +634,7 @@
 					<key>comment</key>
 					<string>comment</string>
 					<key>end</key>
-					<string>$\n?</string>
+					<string>^[\s]*$\n?</string>
 					<key>name</key>
 					<string>comment.line.double-dot.restructuredtext</string>
 				</dict>


### PR DESCRIPTION
.. This is a comment
   Still a comment

Not a comment anymore.

…This is not a comment

`This-is-an-hyperlink, too <http://www.python.org>`_.

This line ends with `double-dot`, thi is **not** a reason to not detect other syntaxes inside it::

```
This is raw
Still raw
```

Not raw anymore.
