### PR TITLE
Update extend_title so that it works for any section title within the document

### DIFF
--- a/Support/extend_title.py
+++ b/Support/extend_title.py
@@ -8,15 +8,17 @@ import os, sys, re
 
 lines = sys.stdin.readlines()
 lines = [i.rstrip() for i in lines]
-# Last line should be the markup line
-match = re.search(r'^(=|-|~|`|#|"|\^|\+|\*)+', lines[-1])
+
+# current line should be the markup line
+currentLine = int(os.environ['TM_LINE_NUMBER']) - 1
+match = re.search(r'^(=|-|~|`|#|"|\^|\+|\*)+', lines[currentLine])
 if not match:
 	# Oops, there needs to be text to match. Don't change anything.
-	print '\n'.join(lines)
+	print 'Cursor is not on a line with a section adornment'
+	print 'i.e. one of: = - ~ ` # " ^ + *'
 	sys.exit(-1)
-lineLen = len(lines[-2].expandtabs(int(os.environ['TM_TAB_SIZE'])))
+lineLen = len(lines[(currentLine-1)].expandtabs(int(os.environ['TM_TAB_SIZE'])))
 # escape snippet characters
 lines = [re.sub(r'([$`\\])', r'\\\1', i) for i in lines]
-lines[-1] = lineLen * lines[-1][0] + '$0'
+lines[currentLine] = lineLen * lines[currentLine][0] + '$0'
 print '\n'.join(lines)
-


### PR DESCRIPTION
Currently extend_title only works if the section is the last line in the file. It would be more useful if it could be used for any title created anywhere in the file.
