### PR TITLE
Allow periods in tags

### DIFF
--- a/Syntaxes/reStructuredText.plist
+++ b/Syntaxes/reStructuredText.plist
@@ -877,7 +877,7 @@
 					<key>comment</key>
 					<string>tags (and field lists</string>
 					<key>match</key>
-					<string>(:)[A-z][A-z0-9  =\s\t_]*(:)</string>
+					<string>(:)[A-z][A-z0-9  =\s\t_.]*(:)</string>
 					<key>name</key>
 					<string>entity.name.tag.restructuredtext</string>
 				</dict>


### PR DESCRIPTION
This is needed for constructs like Sphinx's `:param module.Type argname:`.
