### PR TITLE
Make directive syntax support sphinx domains in directives

### DIFF
--- a/Syntaxes/reStructuredText.plist
+++ b/Syntaxes/reStructuredText.plist
@@ -402,7 +402,7 @@
 					<key>comment</key>
 					<string>directives</string>
 					<key>match</key>
-					<string>(\.\.)\s([A-z][-A-z0-9_]+)(::)\s*$</string>
+					<string>(\.\.)\s([:]?[A-z][-A-z0-9_:]+)(::)\s*$</string>
 					<key>name</key>
 					<string>meta.other.directive.restructuredtext</string>
 				</dict>
@@ -433,7 +433,7 @@
 					<key>comment</key>
 					<string>directives with arguments</string>
 					<key>match</key>
-					<string>(\.\.)\s([A-z][-A-z0-9_]+)(::)\s+(.+?)\s*$</string>
+					<string>(\.\.)\s([:]?[A-z][-A-z0-9_:]+)(::)\s+(.+?)\s*$</string>
 					<key>name</key>
 					<string>meta.other.directive.restructuredtext</string>
 				</dict>


### PR DESCRIPTION
This makes directives like the following correctly syntax highlight:

```
.. :py:module:: mymodule
```

This format is used for directives which belong to a specific sphinx domain.
